### PR TITLE
Handle multiple capture group regexps for matching

### DIFF
--- a/src/cucumber_expression.js
+++ b/src/cucumber_expression.js
@@ -41,7 +41,7 @@ class CucumberExpression {
       this._transforms.push(transform)
 
       const text = expression.slice(matchOffset, match.index)
-      const captureRegexp = `(${transform.captureGroupRegexps[0]})`
+      const captureRegexp = buildCaptureRegexp(transform.captureGroupRegexps)
       matchOffset = parameterPattern.lastIndex
       regexp += text
       regexp += captureRegexp
@@ -58,6 +58,18 @@ class CucumberExpression {
   get source() {
     return this._expression
   }
+}
+
+function buildCaptureRegexp(captureGroupRegexps) {
+  if (captureGroupRegexps.length === 1) {
+    return `(${captureGroupRegexps[0]})`
+  }
+
+  const captureGroups = captureGroupRegexps.map(group => {
+    return `(?:${group})`
+  })
+
+  return `(${captureGroups.join('|')})`
 }
 
 export default CucumberExpression

--- a/test/cucumber_expression_regexp_test.js
+++ b/test/cucumber_expression_regexp_test.js
@@ -22,7 +22,7 @@ describe(CucumberExpression.name, () => {
     it("translates three typed arguments", () => {
       assertRegexp(
         "I have {n:float} cukes in my {bodypart} at {time:int} o'clock",
-        /^I have (-?\d*\.?\d+) cukes in my (.+) at (-?\d+) o'clock$/
+        /^I have (-?\d*\.?\d+) cukes in my (.+) at ((?:-?\d+)|(?:\d+)) o'clock$/
       )
     })
 

--- a/test/custom_transform_test.js
+++ b/test/custom_transform_test.js
@@ -22,7 +22,7 @@ describe('Custom transform', () => {
     transformLookup.addTransform(new Transform(
       'color',
       Color,
-      'red|blue|yellow',
+      ['red|blue|yellow', '(?:dark|light) (?:red|blue|yellow)'],
       s => new Color(s)
     ))
     /// [add-color-transform]
@@ -33,6 +33,12 @@ describe('Custom transform', () => {
       const expression = new CucumberExpression("I have a {color:color} ball", [], transformLookup)
       const transformedArgumentValue = expression.match("I have a red ball")[0].transformedValue
       assert.equal(transformedArgumentValue.name, "red")
+    })
+
+    it("transforms arguments with expression type with additional regexp", () => {
+      const expression = new CucumberExpression("I have a {color:color} ball", [], transformLookup)
+      const transformedArgumentValue = expression.match("I have a dark red ball")[0].transformedValue
+      assert.equal(transformedArgumentValue.name, "dark red")
     })
 
     it("transforms arguments with explicit type", () => {


### PR DESCRIPTION
When creating a new transform with multiple capture group regexps that are not overlapping with the first one, cucumber fail to match expressions that are not using the first capture regexp.

For instance, a transform with the `captureGroupRegexps` with the value `['red', 'yellow']` would fail to match an expression containing yellow.