### PR TITLE
regexp: make CAPTURE_GROUP_PATTERN aware of non-capturing group.

### DIFF
--- a/src/regular_expression.js
+++ b/src/regular_expression.js
@@ -5,7 +5,7 @@ class RegularExpression {
     this._regexp = regexp
     this._parameterTypes = []
 
-    const CAPTURE_GROUP_PATTERN = /\(([^(]+)\)/g
+    const CAPTURE_GROUP_PATTERN = /\((?!\?:)([^(]+)\)/g
 
     let typeIndex = 0
     let match

--- a/test/regular_expression_test.js
+++ b/test/regular_expression_test.js
@@ -39,7 +39,7 @@ describe(RegularExpression.name, () => {
   })
 
   it("take into account non-capturing group", () => {
-    assert.deepEqual(match(/(?:.) (\d+) (.*)/, "head 22 tail"), [22, "tail"])
+    assert.deepEqual(match(/(?:head) (\d+) (tail)/, "head 22 tail"), [22, "tail"])
   })
 
   it("transforms float without integer part", () => {

--- a/test/regular_expression_test.js
+++ b/test/regular_expression_test.js
@@ -38,6 +38,10 @@ describe(RegularExpression.name, () => {
     assert.deepEqual(match(/(\d+)/, "22"), [22])
   })
 
+  it("take into account non-capturing group", () => {
+    assert.deepEqual(match(/(?:.) (\d+) (.*)/, "head 22 tail"), [22, "tail"])
+  })
+
   it("transforms float without integer part", () => {
     assert.deepEqual(match(/(.*)/, ".22", ['float']), [0.22])
   })


### PR DESCRIPTION
Before this patch, non-capturing group would be accounted for in the
match count, wrongly shifting the transformation.

Tests updated, before the patch we get:
```
  1) RegularExpression take into account non-capturing group:

      AssertionError: [ '22', NaN ] deepEqual [ 22, 'tail' ]
      + expected - actual

       [
      -  "22"
      -  NaN
      +  22
      +  "tail"
       ]
```